### PR TITLE
Workflow for build and release github pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,45 @@
+name: Documentation
+
+on:
+  - pull_request
+  # Allows you to run this workflow manually from the Actions tab
+  - workflow_dispatch
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress
+# and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production
+# deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    uses: ./.github/workflows/nox-runs.yml
+    with:
+      session: docs-build
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    if: |
+      contains(
+        '
+          ref/heads/main
+          ref/heads/docs
+        ',
+        github.ref
+      )
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/nox-runs.yml
+++ b/.github/workflows/nox-runs.yml
@@ -99,7 +99,7 @@ jobs:
 
       - name: Upload documentation pages
         if: inputs.session == 'docs-build' && success()
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v3
         with:
           path: ${{ github.workspace }}/site
 


### PR DESCRIPTION
A place where project documentation can live is needed. Instead of creating yet another account on another platform (readthedocs), it's possible to create it on github platform itself.